### PR TITLE
Updates for 0.12

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,25 +6,22 @@
     "output"
   ],
   "dependencies": {
-    "purescript-prelude": "^3.1.1",
-    "purescript-console": "^3.0.0",
-    "purescript-newtype": "^2.0.0",
-    "purescript-maps": "^3.5.2",
-    "purescript-monoid": "^3.3.0",
-    "purescript-generics-rep": "^5.3.0",
-    "purescript-variant": "^4.0.0",
-    "purescript-transformers": "^3.4.0",
-    "purescript-profunctor": "^3.2.0",
-    "purescript-invariant": "^3.0.0",
-    "purescript-run": "^1.0.1",
-    "purescript-foreign": "^4.0.1"
+    "purescript-newtype": "^3.0.0",
+    "purescript-ordered-collections": "^1.0.0",
+    "purescript-generics-rep": "^6.0.0",
+    "purescript-variant": "^5.0.0",
+    "purescript-transformers": "^4.1.0",
+    "purescript-profunctor": "^4.0.0",
+    "purescript-invariant": "^4.0.0",
+    "purescript-run": "^2.0.0",
+    "purescript-foreign": "^5.0.0",
+    "purescript-foreign-object": "^1.0.0"
   },
   "devDependencies": {
-    "purescript-psci-support": "^3.0.0",
-    "purescript-debug": "^3.0.0",
-    "purescript-test-unit": "^13.0.0",
-    "purescript-pux": "^12.0.0",
-    "purescript-affjax": "^5.0.0"
+    "purescript-psci-support": "^4.0.0",
+    "purescript-debug": "^4.0.0",
+    "purescript-test-unit": "^14.0.0",
+    "purescript-affjax": "^6.0.0"
   },
   "license": "BSD-3-Clause",
   "name": "purescript-polyform",

--- a/src/Polyform/Field/Generic.purs
+++ b/src/Polyform/Field/Generic.purs
@@ -8,10 +8,11 @@ import Data.Generic.Rep (class Generic, Constructor(..), NoArguments(..), Sum(..
 import Data.List (List, singleton)
 import Data.Map (fromFoldable, lookup)
 import Data.Maybe (Maybe(..))
-import Data.Record (insert)
+import Record (insert)
 import Data.Tuple (Tuple(Tuple))
 import Polyform.Validation (V(Invalid, Valid), Validation, hoistFnV)
-import Type.Prelude (class IsSymbol, class RowLacks, Proxy(..), SProxy(..), reflectSymbol)
+import Type.Prelude (class IsSymbol, Proxy(..), SProxy(..), reflectSymbol)
+import Prim.Row (class Cons, class Lacks)
 
 -- | This type class provides basic way to transform simple sum type
 -- | (constructors without args are only allowed) into: `Validation` and
@@ -81,7 +82,7 @@ class MultiChoice c (c' ∷ # Type) | c → c' where
       }
 
 instance multiChoiceConstructor
-  ∷ (IsSymbol name, RowCons name Boolean () row, RowLacks name ())
+  ∷ (IsSymbol name, Cons name Boolean () row, Lacks name ())
   ⇒ MultiChoice (Constructor name NoArguments) row where
 
   multiChoiceParserImpl proxy i =
@@ -99,7 +100,7 @@ instance multiChoiceConstructor
       }
 
 instance multiChoiceSum
-  ∷ (IsSymbol name, MultiChoice tail tailRow, RowCons name Boolean tailRow row, RowLacks name tailRow)
+  ∷ (IsSymbol name, MultiChoice tail tailRow, Cons name Boolean tailRow row, Lacks name tailRow)
   ⇒ MultiChoice (Sum (Constructor name NoArguments) tail) row where
 
   multiChoiceParserImpl proxy =

--- a/src/Polyform/Field/Html5.purs
+++ b/src/Polyform/Field/Html5.purs
@@ -10,6 +10,7 @@ import Polyform.Field (Input)
 import Polyform.Field.Validation.Combinators (check, checkAndTag)
 import Polyform.Validation (Validation)
 import Type.Prelude (class IsSymbol, SProxy(SProxy))
+import Prim.Row (class Cons)
 
 check'
   ∷ ∀ a m
@@ -21,7 +22,7 @@ check' = check singleton
 checkAndTag'
   ∷ ∀ a e e' m n
   . Monad m
-  ⇒ RowCons n a e' e
+  ⇒ Cons n a e' e
   ⇒ IsSymbol n
   ⇒ SProxy n
   → (a -> Boolean)

--- a/src/Polyform/Field/Validation/Combinators.purs
+++ b/src/Polyform/Field/Validation/Combinators.purs
@@ -5,11 +5,11 @@ import Prelude
 import Data.Array (catMaybes, uncons)
 import Data.Int (fromString)
 import Data.Maybe (Maybe(..))
-import Data.Monoid (class Monoid)
 import Data.NonEmpty (NonEmpty(..))
 import Data.Variant (Variant, inj, on)
 import Polyform.Validation (V(..), Validation, hoistFnMV, hoistFnV, runValidation)
 import Type.Prelude (class IsSymbol, SProxy(SProxy))
+import Prim.Row (class Cons)
 
 -- | These helpers seems rather useful only
 -- | in case of field validation scenarios
@@ -32,7 +32,7 @@ check singleton f = hoistFnV $ \i →
 checkAndTag
   ∷ ∀ a e err e' m n
   . Monad m
-  ⇒ RowCons n a e' e
+  ⇒ Cons n a e' e
   ⇒ IsSymbol n
   ⇒ Monoid err
   ⇒ (Variant e → err)

--- a/src/Polyform/Form/Component.purs
+++ b/src/Polyform/Form/Component.purs
@@ -3,7 +3,6 @@ module Polyform.Form.Component where
 import Prelude
 
 import Control.Alt (class Alt, (<|>))
-import Data.Monoid (class Monoid, mempty)
 import Data.Newtype (class Newtype, unwrap)
 import Data.Profunctor (class Profunctor)
 import Polyform.Validation (V(..), Validation(..))
@@ -41,7 +40,7 @@ instance semigroupoidComponent ∷ (Monad m, Semigroup e) ⇒ Semigroupoid (Comp
     Component { default: r1.default <> r2.default, validation: r2.validation <<< r1.validation }
 
 instance categoryComponent ∷ (Monad m, Monoid e) ⇒ Category (Component m e) where
-  id = Component { validation: id, default: mempty }
+  identity = Component { validation: identity, default: mempty }
 
 instance profunctorComponent ∷ (Monad m, Monoid e) ⇒ Profunctor (Component m e) where
   dimap l r c = hoistFn l >>> c >>> hoistFn r
@@ -87,7 +86,7 @@ fromField
   → Record (value ∷ V e v | attrs)
   → Validation m e q v
   → Component m form q v
-fromField = fromFieldCoerce id
+fromField = fromFieldCoerce identity
 
 -- | Longer version of previous one which
 -- | allows coersion of field level value

--- a/src/Polyform/Input/Foreign.purs
+++ b/src/Polyform/Input/Foreign.purs
@@ -8,8 +8,8 @@ import Data.Array as Array
 import Data.Bifunctor as Bifunctor
 import Data.Either (Either(..))
 import Data.Foldable (fold)
-import Data.Foreign (Foreign, MultipleErrors, readArray, readInt, readString)
-import Data.Foreign.Index ((!))
+import Foreign (Foreign, MultipleErrors, readArray, readInt, readString)
+import Foreign.Index ((!))
 import Data.Traversable (sequence)
 import Data.Variant (Variant, inj)
 import Polyform.Validation (V(Valid, Invalid), Validation, fromEither, hoistFnMV, hoistFnV, lmapValidation, runValidation)

--- a/src/Polyform/Input/Http.purs
+++ b/src/Polyform/Input/Http.purs
@@ -4,10 +4,9 @@ import Prelude
 
 import Data.Array (catMaybes, singleton)
 import Data.Maybe (Maybe, fromMaybe)
-import Data.Monoid (class Monoid)
 import Data.NonEmpty (NonEmpty)
-import Data.Profunctor (lmap)
-import Data.StrMap (StrMap, lookup)
+import Data.Profunctor (lcmap)
+import Foreign.Object (Object, lookup)
 import Data.Variant (Variant)
 import Polyform.Field.Html5 (IntInputErr, TextInputErr)
 import Polyform.Field.Html5 as Html5
@@ -21,7 +20,7 @@ import Polyform.Validation (V, Validation, hoistFn)
 -- | `?field=value`,
 -- | `?field=value1&field=value2`
 type Value = Array (Maybe String)
-type Query = StrMap Value
+type Query = Object Value
 
 type StringErr e = (scalar ∷ NonEmpty Array String, required ∷ Unit | e)
 type OptStringErr e = (scalar ∷ NonEmpty Array String | e)
@@ -77,7 +76,7 @@ fromFieldCoerce
   → Validation m e Value v
   → Form.Component.Component m form Query v'
 fromFieldCoerce coerce singleton field validation =
-  Form.Component.fromFieldCoerce coerce singleton field (lmap fieldQuery validation)
+  Form.Component.fromFieldCoerce coerce singleton field (lcmap fieldQuery validation)
  where
   fieldQuery query = fromMaybe [] (lookup field.name query)
 
@@ -89,5 +88,5 @@ fromField
   → { value ∷ V e v, name ∷ String | attrs }
   → Validation m e Value v
   → Form.Component.Component m form Query v
-fromField = fromFieldCoerce id
+fromField = fromFieldCoerce identity
 

--- a/src/Polyform/Input/Interpret.purs
+++ b/src/Polyform/Input/Interpret.purs
@@ -4,7 +4,6 @@ import Prelude
 
 import Data.Either (either, note)
 import Data.Maybe (Maybe(..))
-import Data.Monoid (class Monoid)
 import Data.Profunctor (dimap)
 import Data.Profunctor.Choice (right)
 import Polyform.Form.Component (Component, fromField)
@@ -12,11 +11,12 @@ import Polyform.Input.Interpret.Validation (INT, OptIntF, OptStringF, STRING, in
 import Polyform.Validation (V, Validation)
 import Run (FProxy, Run)
 import Type.Prelude (class IsSymbol, SProxy)
+import Prim.Row (class Cons)
 
 intForm
   ∷ ∀ attrs e eff form q n ns ns' v
   . Monoid e
-  ⇒ RowCons n Unit ns ns'
+  ⇒ Cons n Unit ns ns'
   ⇒ IsSymbol n
   ⇒ ({ value ∷ V e v, name ∷ SProxy n | attrs } -> form)
   → { value :: V e v , name :: SProxy n | attrs }
@@ -53,11 +53,11 @@ optIntForm singleton field validation =
  where
   validation'
     = optInt field.name
-    >>> dimap (note Nothing) (either id Just) (right validation)
+    >>> dimap (note Nothing) (either identity Just) (right validation)
 
 stringForm
   ∷ ∀ attrs e eff form q n ns ns' v
-  . RowCons n Unit ns ns'
+  . Cons n Unit ns ns'
   ⇒ IsSymbol n
   ⇒ Semigroup e
   ⇒ ({ value ∷ V e v, name ∷ SProxy n | attrs } -> form)
@@ -95,4 +95,4 @@ optStringForm singleton field validation =
  where
   validation'
     = optString field.name
-    >>> dimap (note Nothing) (either id Just) (right validation)
+    >>> dimap (note Nothing) (either identity Just) (right validation)

--- a/src/Polyform/Input/Interpret/Http.purs
+++ b/src/Polyform/Input/Interpret/Http.purs
@@ -6,7 +6,7 @@ import Data.Array (catMaybes, singleton)
 import Data.Functor.Variant (VariantF)
 import Data.Maybe (Maybe, fromMaybe)
 import Data.NonEmpty (NonEmpty)
-import Data.StrMap (StrMap, lookup)
+import Foreign.Object (Object, lookup)
 import Data.Variant (Variant)
 import Data.Variant.Internal (VariantRep(..))
 import Polyform.Field.Validation.Combinators (int, required, scalar)
@@ -22,7 +22,7 @@ import Unsafe.Coerce (unsafeCoerce)
 -- | `?field`, `?field=`, `?field=value`,
 -- | `?field=value1&field=value2`
 type Value = Array (Maybe String)
-type Query = StrMap Value
+type Query = Object Value
 
 variantTag ∷ ∀ v. Variant v → String
 variantTag v =
@@ -77,7 +77,7 @@ onField :: forall t139 t145 t146 t147 t154 t155 t156.
                                              )
                                           )
                                        )
-                                       (StrMap (Array (Maybe String)))
+                                       (Object (Array (Maybe String)))
                                     )
                       , int :: FProxy
                                  (IntF (Variant t145)
@@ -90,7 +90,7 @@ onField :: forall t139 t145 t146 t147 t154 t155 t156.
                                           )
                                        )
                                     )
-                                    (StrMap (Array (Maybe String)))
+                                    (Object (Array (Maybe String)))
                                  )
                       | t139
                       )
@@ -110,7 +110,7 @@ handle :: forall t103 t111 t112 t120 t121 t122.
                                           )
                                        )
                                     )
-                                    (StrMap (Array (Maybe String)))
+                                    (Object (Array (Maybe String)))
                                  )
                    , int :: FProxy
                               (IntF (Variant t111)
@@ -123,7 +123,7 @@ handle :: forall t103 t111 t112 t120 t121 t122.
                                        )
                                     )
                                  )
-                                 (StrMap (Array (Maybe String)))
+                                 (Object (Array (Maybe String)))
                               )
                    )
                    t103

--- a/src/Polyform/Input/Interpret/Record.purs
+++ b/src/Polyform/Input/Interpret/Record.purs
@@ -2,20 +2,20 @@ module Polyform.Input.Interpret.Record where
 
 import Prelude
 
-import Data.Monoid (class Monoid)
 import Data.Variant (Variant)
 import Data.Variant.Internal (VariantRep(VariantRep), unsafeGet)
 import Polyform.Input.Interpret.Validation (IntF(..), StringF(..), _int, _string)
 import Run (FProxy, Run, VariantF, case_, on)
 import Run as Run
 import Type.Row (class RowToList, Cons, Nil, kind RowList)
+import Prim.Row (class Cons)
 import Unsafe.Coerce (unsafeCoerce)
 
 class VariantFieldsType (rl ∷ RowList) (vo ∷ # Type) a | rl a → vo
 
-instance a_variantFieldsTypeSame ∷ (VariantFieldsType rl vo' a, RowCons sym Unit vo' vo) ⇒ VariantFieldsType (Cons sym a rl) vo a
-instance b_variantFieldsTypeDiff ∷ (VariantFieldsType rl vo a) ⇒ VariantFieldsType (Cons sym b rl) vo a
-instance c_variantFieldsTypeNil ∷ VariantFieldsType Nil () a
+instance a_variantFieldsTypeSame ∷ (VariantFieldsType rl vo' a, Cons sym Unit vo' vo) ⇒ VariantFieldsType (Cons sym a rl) vo a
+else instance b_variantFieldsTypeDiff ∷ (VariantFieldsType rl vo a) ⇒ VariantFieldsType (Cons sym b rl) vo a
+else instance c_variantFieldsTypeNil ∷ VariantFieldsType Nil () a
 
 onMatch
   ∷ ∀ a rl r v

--- a/src/Polyform/Input/Interpret/Validation.purs
+++ b/src/Polyform/Input/Interpret/Validation.purs
@@ -8,6 +8,7 @@ import Polyform.Validation (V, Validation(..))
 import Run (FProxy, Run)
 import Run as Run
 import Type.Prelude (class IsSymbol, SProxy(..))
+import Prim.Row (class Cons)
 
 data StringF n e q a = StringF n q (V e String → a)
 derive instance functorStringF ∷ Functor (StringF n q e)
@@ -17,13 +18,13 @@ type STRING n e q = FProxy (StringF (Variant n) e q)
 _string = SProxy :: SProxy "string"
 
 string ∷ ∀ e q eff name names names'
-  . RowCons name Unit names names'
+  . Cons name Unit names names'
   ⇒ IsSymbol name
   ⇒ SProxy name
   → Validation
       (Run (string ∷ (STRING names' e q) | eff)) e q String
 string name =
-  Validation \q → (Run.lift _string (StringF (inj name unit) q id))
+  Validation \q → (Run.lift _string (StringF (inj name unit) q identity))
 
 
 data OptStringF n q e a = OptStringF (SProxy n) q (V e (Maybe String) → a)
@@ -39,7 +40,7 @@ optString
   → Validation
       (Run (optString ∷ OPTSTRING n q e a | eff)) e q (Maybe String)
 optString name =
-  Validation \q → Run.lift _optString (OptStringF name q id)
+  Validation \q → Run.lift _optString (OptStringF name q identity)
 
 
 data IntF n e q a = IntF n q (V e Int → a)
@@ -51,13 +52,13 @@ _int = SProxy :: SProxy "int"
 
 int
   ∷ ∀ e q eff name names names'
-  . RowCons name Unit names names'
+  . Cons name Unit names names'
   ⇒ IsSymbol name
   ⇒ SProxy name
   → Validation
     (Run ( int :: (INT names' e q) | eff)) e q Int
 int name =
-  Validation \q → Run.lift _int (IntF (inj name unit) q id)
+  Validation \q → Run.lift _int (IntF (inj name unit) q identity)
 
 
 data OptIntF n q e a = OptIntF (SProxy n) q (V e (Maybe Int) → a)
@@ -73,5 +74,5 @@ optInt
   → Validation
       (Run (optInt ∷ OPTINT n q e a | eff)) e q (Maybe Int)
 optInt name =
-  Validation \q → Run.lift _optInt (OptIntF name q id)
+  Validation \q → Run.lift _optInt (OptIntF name q identity)
 

--- a/src/Polyform/Validation.purs
+++ b/src/Polyform/Validation.purs
@@ -6,7 +6,6 @@ import Control.Alt (class Alt, (<|>))
 import Control.Apply (lift2)
 import Data.Bifunctor (class Bifunctor, bimap, lmap, rmap)
 import Data.Either (Either(..))
-import Data.Monoid (class Monoid, mempty)
 import Data.Newtype (class Newtype, unwrap)
 import Data.Profunctor (class Profunctor)
 import Data.Profunctor.Choice (class Choice)
@@ -117,7 +116,7 @@ instance semigroupoidValidation ∷ (Monad m, Semigroup e) ⇒ Semigroupoid (Val
         Invalid e → pure (Invalid e))
 
 instance categoryValidation ∷ (Monad m, Monoid e) ⇒ Category (Validation m e) where
-  id = Validation $ pure <<< pure
+  identity = Validation $ pure <<< pure
 
 instance profunctorValidation ∷ (Monad m, Monoid e) ⇒ Profunctor (Validation m e) where
   dimap l r v = (hoistFn l) >>> v >>> (hoistFn r)

--- a/src/Polyform/Validation/Par.purs
+++ b/src/Polyform/Validation/Par.purs
@@ -5,7 +5,6 @@ import Prelude
 import Control.Alt (class Alt, (<|>))
 import Control.Parallel (class Parallel)
 import Control.Parallel as Parallel
-import Data.Monoid (class Monoid)
 import Data.Newtype (class Newtype)
 import Polyform.Validation (Validation(..))
 

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -3,18 +3,11 @@ module Test.Main where
 import Prelude
 import Test.Polyform.Field.Generic as Generic
 import Test.Polyform.Input.Http as Http
-import Control.Monad.Aff.AVar (AVAR)
-import Control.Monad.Eff (Eff)
-import Control.Monad.Eff.Timer (TIMER)
-import Control.Monad.Eff.Console (CONSOLE)
+import Effect (Effect)
 import Test.Unit (suite)
-import Test.Unit.Console (TESTOUTPUT)
 import Test.Unit.Main (runTest)
 
-main :: forall eff. Eff ( timer :: TIMER
-                        , avar :: AVAR
-                        , console :: CONSOLE
-                        , testOutput :: TESTOUTPUT | eff ) Unit
+main :: Effect Unit
 main = runTest $ do
   suite "Polyform.Field.Generic" Generic.suite
   suite "Polyform.Input.Http" Http.suite


### PR DESCRIPTION
Hi @paluh! We use this in `purescript-ocelot` which we're trying to migrate to 0.12, so I went ahead and implemented those changes across Polyform. I've maintained the same functionality throughout, just updated everything to use:

- `identity` instead of `id`
- `Effect` instead of `Eff` and removed all effect rows
- `Cons` and `Lacks` instead of `RowCons` and `RowLacks`
- `Foreign.Object` instead of `Data.StrMap`
- `lcmap` instead of `lmap` from profunctor
- etc.

I removed some unnecessary imports as well. Tests all pass and this should be good to go for `0.7` release!